### PR TITLE
Added SplitContainer and docking behavior for a responsive UI.

### DIFF
--- a/DataExportValidationChecker/DataExportValidationChecker/DataExportValidationCheckerPluginControl.designer.cs
+++ b/DataExportValidationChecker/DataExportValidationChecker/DataExportValidationCheckerPluginControl.designer.cs
@@ -39,12 +39,19 @@
             this.button1 = new System.Windows.Forms.Button();
             this.resultsGroupBox = new System.Windows.Forms.GroupBox();
             this.resultsView = new System.Windows.Forms.DataGridView();
+            this.splitContainer1 = new System.Windows.Forms.SplitContainer();
+            this.panelButtons = new System.Windows.Forms.Panel();
             this.toolStripMenu.SuspendLayout();
             this.loadGroupBox.SuspendLayout();
             this.previewGroup.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.metadataView)).BeginInit();
             this.resultsGroupBox.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.resultsView)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.splitContainer1)).BeginInit();
+            this.splitContainer1.Panel1.SuspendLayout();
+            this.splitContainer1.Panel2.SuspendLayout();
+            this.splitContainer1.SuspendLayout();
+            this.panelButtons.SuspendLayout();
             this.SuspendLayout();
             // 
             // toolStripMenu
@@ -55,7 +62,7 @@
             this.tssSeparator1});
             this.toolStripMenu.Location = new System.Drawing.Point(0, 0);
             this.toolStripMenu.Name = "toolStripMenu";
-            this.toolStripMenu.Size = new System.Drawing.Size(1386, 25);
+            this.toolStripMenu.Size = new System.Drawing.Size(841, 25);
             this.toolStripMenu.TabIndex = 4;
             this.toolStripMenu.Text = "toolStrip1";
             // 
@@ -81,7 +88,7 @@
             this.entitySelection.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
             this.entitySelection.Name = "entitySelection";
             this.entitySelection.Service = null;
-            this.entitySelection.Size = new System.Drawing.Size(469, 32);
+            this.entitySelection.Size = new System.Drawing.Size(274, 32);
             this.entitySelection.SolutionFilter = null;
             this.entitySelection.TabIndex = 5;
             this.entitySelection.SelectedItemChanged += new System.EventHandler(this.entitySelection_SelectedItemChanged);
@@ -90,9 +97,10 @@
             // loadGroupBox
             // 
             this.loadGroupBox.Controls.Add(this.entitySelection);
-            this.loadGroupBox.Location = new System.Drawing.Point(8, 28);
+            this.loadGroupBox.Dock = System.Windows.Forms.DockStyle.Top;
+            this.loadGroupBox.Location = new System.Drawing.Point(0, 0);
             this.loadGroupBox.Name = "loadGroupBox";
-            this.loadGroupBox.Size = new System.Drawing.Size(475, 51);
+            this.loadGroupBox.Size = new System.Drawing.Size(280, 51);
             this.loadGroupBox.TabIndex = 7;
             this.loadGroupBox.TabStop = false;
             this.loadGroupBox.Text = "Load Metadata";
@@ -100,9 +108,10 @@
             // previewGroup
             // 
             this.previewGroup.Controls.Add(this.metadataView);
-            this.previewGroup.Location = new System.Drawing.Point(8, 86);
+            this.previewGroup.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.previewGroup.Location = new System.Drawing.Point(0, 51);
             this.previewGroup.Name = "previewGroup";
-            this.previewGroup.Size = new System.Drawing.Size(480, 375);
+            this.previewGroup.Size = new System.Drawing.Size(280, 433);
             this.previewGroup.TabIndex = 8;
             this.previewGroup.TabStop = false;
             this.previewGroup.Text = "Preview Metadata";
@@ -118,15 +127,17 @@
             this.metadataView.Location = new System.Drawing.Point(3, 16);
             this.metadataView.Name = "metadataView";
             this.metadataView.RowHeadersVisible = false;
-            this.metadataView.Size = new System.Drawing.Size(474, 356);
+            this.metadataView.Size = new System.Drawing.Size(274, 414);
             this.metadataView.TabIndex = 0;
             this.metadataView.CellEnter += new System.Windows.Forms.DataGridViewCellEventHandler(this.metadataView_CellEnter);
             // 
             // checkButton
             // 
-            this.checkButton.Location = new System.Drawing.Point(8, 464);
+            this.checkButton.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.checkButton.Location = new System.Drawing.Point(3, 3);
             this.checkButton.Name = "checkButton";
-            this.checkButton.Size = new System.Drawing.Size(473, 30);
+            this.checkButton.Size = new System.Drawing.Size(274, 30);
             this.checkButton.TabIndex = 9;
             this.checkButton.Text = "Validate Selected Fields ->";
             this.checkButton.UseVisualStyleBackColor = true;
@@ -134,9 +145,11 @@
             // 
             // button1
             // 
-            this.button1.Location = new System.Drawing.Point(8, 500);
+            this.button1.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.button1.Location = new System.Drawing.Point(3, 39);
             this.button1.Name = "button1";
-            this.button1.Size = new System.Drawing.Size(473, 30);
+            this.button1.Size = new System.Drawing.Size(274, 30);
             this.button1.TabIndex = 9;
             this.button1.Text = "Validate All Fields ->";
             this.button1.UseVisualStyleBackColor = true;
@@ -145,9 +158,10 @@
             // resultsGroupBox
             // 
             this.resultsGroupBox.Controls.Add(this.resultsView);
-            this.resultsGroupBox.Location = new System.Drawing.Point(494, 28);
+            this.resultsGroupBox.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.resultsGroupBox.Location = new System.Drawing.Point(0, 0);
             this.resultsGroupBox.Name = "resultsGroupBox";
-            this.resultsGroupBox.Size = new System.Drawing.Size(450, 502);
+            this.resultsGroupBox.Size = new System.Drawing.Size(557, 560);
             this.resultsGroupBox.TabIndex = 7;
             this.resultsGroupBox.TabStop = false;
             this.resultsGroupBox.Text = "Results";
@@ -162,22 +176,47 @@
             this.resultsView.Location = new System.Drawing.Point(3, 16);
             this.resultsView.Name = "resultsView";
             this.resultsView.RowHeadersVisible = false;
-            this.resultsView.Size = new System.Drawing.Size(444, 483);
+            this.resultsView.Size = new System.Drawing.Size(551, 541);
             this.resultsView.TabIndex = 1;
             this.resultsView.CellMouseDoubleClick += new System.Windows.Forms.DataGridViewCellMouseEventHandler(this.resultsView_CellMouseDoubleClick);
+            // 
+            // splitContainer1
+            // 
+            this.splitContainer1.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.splitContainer1.Location = new System.Drawing.Point(0, 25);
+            this.splitContainer1.Name = "splitContainer1";
+            // 
+            // splitContainer1.Panel1
+            // 
+            this.splitContainer1.Panel1.Controls.Add(this.previewGroup);
+            this.splitContainer1.Panel1.Controls.Add(this.panelButtons);
+            this.splitContainer1.Panel1.Controls.Add(this.loadGroupBox);
+            // 
+            // splitContainer1.Panel2
+            // 
+            this.splitContainer1.Panel2.Controls.Add(this.resultsGroupBox);
+            this.splitContainer1.Size = new System.Drawing.Size(841, 560);
+            this.splitContainer1.SplitterDistance = 280;
+            this.splitContainer1.TabIndex = 10;
+            // 
+            // panelButtons
+            // 
+            this.panelButtons.Controls.Add(this.button1);
+            this.panelButtons.Controls.Add(this.checkButton);
+            this.panelButtons.Dock = System.Windows.Forms.DockStyle.Bottom;
+            this.panelButtons.Location = new System.Drawing.Point(0, 484);
+            this.panelButtons.Name = "panelButtons";
+            this.panelButtons.Size = new System.Drawing.Size(280, 76);
+            this.panelButtons.TabIndex = 8;
             // 
             // DataExportValidationCheckerPluginControl
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.Controls.Add(this.button1);
-            this.Controls.Add(this.checkButton);
-            this.Controls.Add(this.previewGroup);
-            this.Controls.Add(this.resultsGroupBox);
-            this.Controls.Add(this.loadGroupBox);
+            this.Controls.Add(this.splitContainer1);
             this.Controls.Add(this.toolStripMenu);
             this.Name = "DataExportValidationCheckerPluginControl";
-            this.Size = new System.Drawing.Size(1386, 771);
+            this.Size = new System.Drawing.Size(841, 585);
             this.Load += new System.EventHandler(this.MyPluginControl_Load);
             this.toolStripMenu.ResumeLayout(false);
             this.toolStripMenu.PerformLayout();
@@ -186,6 +225,11 @@
             ((System.ComponentModel.ISupportInitialize)(this.metadataView)).EndInit();
             this.resultsGroupBox.ResumeLayout(false);
             ((System.ComponentModel.ISupportInitialize)(this.resultsView)).EndInit();
+            this.splitContainer1.Panel1.ResumeLayout(false);
+            this.splitContainer1.Panel2.ResumeLayout(false);
+            ((System.ComponentModel.ISupportInitialize)(this.splitContainer1)).EndInit();
+            this.splitContainer1.ResumeLayout(false);
+            this.panelButtons.ResumeLayout(false);
             this.ResumeLayout(false);
             this.PerformLayout();
 
@@ -203,5 +247,7 @@
         private System.Windows.Forms.Button button1;
         private System.Windows.Forms.GroupBox resultsGroupBox;
         private System.Windows.Forms.DataGridView resultsView;
+        private System.Windows.Forms.SplitContainer splitContainer1;
+        private System.Windows.Forms.Panel panelButtons;
     }
 }


### PR DESCRIPTION
This is what I did:

1. Added a `SplitContainer` to the form.
2. Dragged the `resultsGroupBox` onto the right panel of the SplitContainer and set `Dock=Fill`
3. Dragged the `loadGroupBox` onto the left panel and set `Dock=Top`
4. Added new `panelButtons` to the left panel and set `Dock=Bottom`
5. Dragged the two buttons to the new panel and set `Anchor=Top,Left,Right` on them
6. Dragged the `previewGroup` onto the left panel and set `Dock=Fill`
7. Selected the `splitContainer1` and set `Dock=Fill`

This created a fully responsive layout and the possibility to drag the splitter between the left and right panels!